### PR TITLE
Handle Heroku buildpack detection failure

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bin/boot

--- a/static.json
+++ b/static.json
@@ -1,0 +1,9 @@
+{
+  "root": "igac-website-clone/",
+  "clean_urls": true,
+  "https_only": true,
+  "error_page": "igac.info/index.html",
+  "routes": {
+    "/**": "igac.info/index.html"
+  }
+}


### PR DESCRIPTION
Add `Procfile` and `static.json` to configure Heroku's static buildpack, resolving the 'No default language detected' build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-5efdfdfa-3f7e-4c29-911c-ece25fe26b01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5efdfdfa-3f7e-4c29-911c-ece25fe26b01">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>